### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Then set your mongodb environment:
         mogno
         rs.initiate()
 
-The next step you shoud initialize the database.
+The next step you should initialize the database.
 
     fab init
 

--- a/app/home/document.py
+++ b/app/home/document.py
@@ -42,7 +42,7 @@ class StatusDocument(Document):
 
     @gen.coroutine
     def translate_at(content):
-        '''将status cotent中的@转换成链接'''
+        '''将status content中的@转换成链接'''
 
         result = StatusDocument.REGEX_AT.findall(content)
 

--- a/young/setting.py
+++ b/young/setting.py
@@ -5,7 +5,7 @@ import os
 ROOT_LOCATION = os.path.dirname(os.path.dirname(__file__))
 
 APPLICATION_SETTINGS = {
-    # NOTE: please use nginx to serve static file in production enviroment
+    # NOTE: please use nginx to serve static file in production environment
     'static_path': ROOT_LOCATION + '/static/',
     'login_url': '/login',
     'xsrf_cookies': True,


### PR DESCRIPTION
There are small typos in:
- README.md
- app/home/document.py
- young/setting.py

Fixes:
- Should read `should` rather than `shoud`.
- Should read `environment` rather than `enviroment`.
- Should read `content` rather than `cotent`.

Closes #11